### PR TITLE
feat(deps): add fast-forward/enum to framework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add changelog history for releases v1.0.0-v1.3.0 during dev-tools asset synchronization. (#3)
 - Sync latest Fast Forward dev-tools managed assets (workflow templates, governance metadata, agents, and skills) into this repository. (#3)
 - Add repository AGENTS.md for agent task orchestration and local onboarding flow.
+- Add fast-forward/enum to framework dependencies as a core metapackage component. (#2)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add changelog history for releases v1.0.0-v1.3.0 during dev-tools asset synchronization. (#3)
 - Sync latest Fast Forward dev-tools managed assets (workflow templates, governance metadata, agents, and skills) into this repository. (#3)
 - Add repository AGENTS.md for agent task orchestration and local onboarding flow.
-- Add fast-forward/enum to framework dependencies as a core metapackage component. (#2)
+- Add ``fast-forward/enum`` as an installed package in the framework metapackage and
+  document its presence in package surface guidance. (#6)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ $clock = $container->get(ClockInterface::class);
 ## 🔌 Package Surface
 
 - `FastForward\Framework\ServiceProvider\FrameworkServiceProvider`
+- `fast-forward/enum` (enum utilities and value object helpers included by composition)
 - Core HTTP and event-dispatcher service provider orchestration
 - Shared configuration and lifecycle defaults for core packages in the ecosystem
 

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
         "fast-forward/config": "^1.4",
         "fast-forward/container": "^1.5",
         "fast-forward/defer": "^1.0",
+        "fast-forward/enum": "^0.1",
         "fast-forward/event-dispatcher": "^1.0",
         "fast-forward/fork": "^1.0",
         "fast-forward/http": "^1.0",

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -38,8 +38,8 @@ Are all installed packages automatically available from the container?
 ---------------------------------------------------------------------
 
 No. ``fast-forward/config``, ``fast-forward/defer``, ``fast-forward/fork``, and
-``fast-forward/iterators`` are installed, but they are not automatically registered in the
-container by ``FrameworkServiceProvider``.
+``fast-forward/iterators`` and ``fast-forward/enum`` are installed, but they are not
+automatically registered in the container by ``FrameworkServiceProvider``.
 
 How do I build the container?
 -----------------------------

--- a/docs/getting-started/installation.rst
+++ b/docs/getting-started/installation.rst
@@ -8,7 +8,7 @@ Install the metapackage with Composer:
    composer require fast-forward/framework
 
 This single command installs the Fast Forward container, configuration helpers, HTTP stack,
-event-dispatcher stack, deferred callback utilities, iterator helpers, and process-management tools.
+event-dispatcher stack, deferred callback utilities, enum helpers, iterator helpers, and process-management tools.
 
 Requirements
 ------------
@@ -46,6 +46,9 @@ one local service provider class, while Composer pulls in the runtime libraries 
      - No
    * - ``fast-forward/fork``
      - Parallel worker orchestration for CLI workloads
+     - No
+   * - ``fast-forward/enum``
+     - Enum and value-object helper abstractions for explicit domain modeling
      - No
    * - ``fast-forward/iterators``
      - Iterator utilities for grouping, chunking, lookahead, and related data flows

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,7 +24,7 @@ Documentation
 
       - a PSR-11 friendly container workflow
       - the Fast Forward HTTP and event-dispatcher service-provider stacks
-      - access to supporting packages such as configuration, deferred callbacks, iterators, and process tools
+      - access to supporting packages such as configuration, deferred callbacks, enum helpers, iterators, and process tools
 
    .. container:: col-lg-5 text-center
 

--- a/docs/links/dependencies.rst
+++ b/docs/links/dependencies.rst
@@ -39,6 +39,10 @@ Direct runtime packages
      - Parallel worker orchestration for CLI applications
      - No
      - `Docs <https://github.com/php-fast-forward/fork>`_
+   * - ``fast-forward/enum``
+     - Enum abstractions and value-object helpers for safer domain modeling
+     - No
+     - `Docs <https://github.com/php-fast-forward/enum>`_
    * - ``fast-forward/iterators``
      - Iterator utilities for chunking, grouping, lookahead, and data traversal
      - No


### PR DESCRIPTION
## Summary

Implements issue #2 by adding `fast-forward/enum` to the framework package dependencies.

## Changes

- Add `fast-forward/enum` to `require` in `composer.json` with version constraint `^0.1`.
- Add changelog entry under `Unreleased` in `CHANGELOG.md`:
  - Add fast-forward/enum to framework dependencies as a core metapackage component. (#2)

## Validation

- `composer dev-tools changelog:check -- --against=refs/remotes/origin/main` ✅
- `composer require fast-forward/enum:^0.1` (lock and install validation) ✅

CI continues to run full test verification via repository workflows.

Closes #2
